### PR TITLE
add line about scrolling up to select nano

### DIFF
--- a/_includes/swc/setup.html
+++ b/_includes/swc/setup.html
@@ -29,6 +29,7 @@
                 <strong>
                   From the dropdown menu select "Use the nano editor by default" and click on "Next".
                 </strong>
+		You may have to scroll up to see the option. It should be above the Vim option.
               </li>
               {% comment %} Adjusting your PATH environment {% endcomment %}
               <li>


### PR DESCRIPTION
template update from https://github.com/svigneau/2020-06-09-uofdelaware-online/pull/2 where students were unable to select and find nano as an editor option.

I believe nano used to be selected by default, (at least in 2.23) but the 2.27.0 git installer defaults to vim and nano is the option *above* the default selected text editor option.